### PR TITLE
add support for classname minification and pseudo class handling.

### DIFF
--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -15,7 +15,7 @@ export const addClasses = (classes: string[]) => {
     classCache.add(className);
     const cssString = classes[x + 1];
 
-    css += `.${className}${cssString}\n`;
+    css += `${cssString}\n`;
     x++;
   }
 


### PR DESCRIPTION
This is working but very hard to read and maintain.
There must be a better way to structure this.

The main idea here is that we have tow sets of class names the internal one and the mapped one.
When outputting we always use `getClassname(internalClassName)` to get the mapped one.

Additional in the css a ":" must be escaped so that must be handled differnetly too.