### PR TITLE
Allow config to be derived from defaults using functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "module": "es/index.js",
   "types": "lib/classy-ui.d.ts",
   "scripts": {
-    "build": "npm run build:lib & npm run build:es && node lib/config/create-types-script",
+    "build": "npm run build:lib & npm run build:es && node lib/config/create-types-script.js",
     "build:lib": "tsc --outDir lib --module commonjs",
     "build:es": "tsc --outDir es --module es2015",
     "clean": "rimraf es lib coverage",


### PR DESCRIPTION
This PR is intended to allow configuring the tokens in `classy-ui.config.js` using functions as the return values. This allows people to derive tokens from defaultTokens without requiring to import `classy-ui/tokens`. This can be done on a per token-category basis as well. The functionality it allows is:

```javascript
module.exports = {
  tokens: {
    spacing: spacing => ({
      ...spacing,
      oneLine: "32px",
      twoLines: "64px",
      threeLines: "96px",
      fourLines: "128px"
    }),
  }
};
```

```javascript
const theme = require("./src/core/theme");

module.exports = ({ tokens: defaultTokens }) => ({
  tokens: {
    ...defaultTokens,
    colors: theme.colors,
    spacing: spacing => ({
      ...spacing,
      oneLine: "32px",
      twoLines: "64px",
      threeLines: "96px",
      fourLines: "128px"
    }),
    lineHeight: (lineHeight) => ({
      ...lineHeight,
      ...defaultTokens.spacing,
      oneLine: "32px"
    }),
    fontSizes: {
      ...defaultTokens.fontSizes,
      size: fontSizes
    }
  }
});
```